### PR TITLE
Replace panics with contextual error messages in cp-plugin

### DIFF
--- a/changelogs/unreleased/331-chlins
+++ b/changelogs/unreleased/331-chlins
@@ -1,0 +1,1 @@
+Replace panics with contextual error messages in cp-plugin

--- a/hack/cp-plugin/main.go
+++ b/hack/cp-plugin/main.go
@@ -18,25 +18,30 @@ Usage: cp-plugin src dst`)
 	fmt.Printf("Copying %s to %s ...  ", src, dst)
 	srcFile, err := os.Open(src)
 	if err != nil {
-		panic(err)
+		exitOnError("open source file %s: %v", src, err)
 	}
 	defer srcFile.Close()
 	if _, err := os.Stat(dst); errors.Is(err, os.ErrNotExist) {
 		_, err = os.Create(dst)
 		if err != nil {
-			panic(err)
+			exitOnError("create destination file %s: %v", dst, err)
 		}
 	}
 	dstFile, err := os.OpenFile(dst, os.O_WRONLY, 0755)
 	if err != nil {
-		panic(err)
+		exitOnError("open destination file %s for writing: %v", dst, err)
 	}
 	defer dstFile.Close()
 	buf := make([]byte, 1024*128)
 	_, err = io.CopyBuffer(dstFile, srcFile, buf)
 	if err != nil {
-		panic(err)
+		exitOnError("copy %s to %s: %v", src, dst, err)
 	}
 	os.Chmod(dst, 0755)
 	fmt.Println("done.")
+}
+
+func exitOnError(format string, args ...any) {
+	fmt.Fprintf(os.Stderr, "Error: failed to "+format+"\n", args...)
+	os.Exit(1)
 }


### PR DESCRIPTION
## Summary

The `cp-plugin` helper (used by the init container to copy the plugin binary into the Velero plugins directory) had four bare `panic(err)` calls. When the copy fails (missing file, permissions, read-only volume), the operator sees a raw Go stack trace in `kubectl logs` instead of a diagnosis.

This PR replaces the panics with contextual error messages written to stderr plus `os.Exit(1)`:

```
Error: failed to open source file /plugins/velero-plugin-for-aws: open ...: no such file or directory
```

Covers all four failure points: opening the source file, creating the destination, opening the destination for writing, and the copy itself. No behavior change beyond the error output.

Verified: `go build`, failure path (missing source shows the message above, exit 1), success path (file copied, 0755 preserved).
