### PR TITLE
[release-1.14] Replace panics with contextual error messages in cp-plugin

### DIFF
--- a/changelogs/unreleased/332-chlins
+++ b/changelogs/unreleased/332-chlins
@@ -1,0 +1,1 @@
+Replace panics with contextual error messages in cp-plugin

--- a/hack/cp-plugin/main.go
+++ b/hack/cp-plugin/main.go
@@ -18,25 +18,30 @@ Usage: cp-plugin src dst`)
 	fmt.Printf("Copying %s to %s ...  ", src, dst)
 	srcFile, err := os.Open(src)
 	if err != nil {
-		panic(err)
+		exitOnError("open source file %s: %v", src, err)
 	}
 	defer srcFile.Close()
 	if _, err := os.Stat(dst); errors.Is(err, os.ErrNotExist) {
 		_, err = os.Create(dst)
 		if err != nil {
-			panic(err)
+			exitOnError("create destination file %s: %v", dst, err)
 		}
 	}
 	dstFile, err := os.OpenFile(dst, os.O_WRONLY, 0755)
 	if err != nil {
-		panic(err)
+		exitOnError("open destination file %s for writing: %v", dst, err)
 	}
 	defer dstFile.Close()
 	buf := make([]byte, 1024*128)
 	_, err = io.CopyBuffer(dstFile, srcFile, buf)
 	if err != nil {
-		panic(err)
+		exitOnError("copy %s to %s: %v", src, dst, err)
 	}
 	os.Chmod(dst, 0755)
 	fmt.Println("done.")
+}
+
+func exitOnError(format string, args ...any) {
+	fmt.Fprintf(os.Stderr, "Error: failed to "+format+"\n", args...)
+	os.Exit(1)
 }


### PR DESCRIPTION
## Summary

Cherry-pick of #331 to release-1.14 (clean pick of a7dd7ad, no conflicts).

Replaces the four bare `panic(err)` calls in the `cp-plugin` init-container helper with contextual error messages on stderr plus `os.Exit(1)`, so a failed plugin install reports which file operation failed instead of a Go stack trace.

Verified on release-1.14: `go build ./...`, failure path (missing source prints `Error: failed to open source file ...`, exit 1) and success path (file copied, 0755 preserved).

Backport of #331.
